### PR TITLE
Make TorIpChanger compatible with Python 3.5 (don't use fstrings)

### DIFF
--- a/scripts/toripchanger_server
+++ b/scripts/toripchanger_server
@@ -13,8 +13,8 @@ except ImportError as exc:
         raise
 
     sys.exit(
-        f"{str(exc)}\nflask is required to to use `toripchanger_server`. Run "
-        "'pip install toripchanger[server]' to install required dependencies"
+        "{}\nflask is required to to use `toripchanger_server`. Run "
+        "'pip install toripchanger[server]' to install required dependencies".format(str(exc))
     )
 
 
@@ -50,7 +50,7 @@ def parse_cmd_args():
     )
     parser.add_argument(
         "--tor-password",
-        default=f"\"{changer.TOR_PASSWORD}\"",
+        default="\"{}\"".format(changer.TOR_PASSWORD),
         type=str,
         help="Tor controller password",
     )

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,8 @@ from setuptools import setup
 
 
 def read(fname, readlines=False):
-    with open(
-        path.join(path.abspath(path.dirname(__file__)), fname), encoding="utf-8"
-    ) as f:
-        return f.read()
+    with open(path.join(path.abspath(path.dirname(__file__)), fname)) as f:
+        return f.readlines() if readlines else f.read()
 
 
 requirements = read("requirements.txt", True)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     test_suite="tests",
     license="MIT",
     platforms="linux",
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     install_requires=requirements,
     tests_require=requirements + requirements_server,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,10 @@ from setuptools import setup
 
 
 def read(fname, readlines=False):
-    with open(path.join(path.abspath(path.dirname(__file__)), fname)) as f:
-        return f.readlines() if readlines else f.read()
+    with open(
+        path.join(path.abspath(path.dirname(__file__)), fname), encoding="utf-8"
+    ) as f:
+        return f.read()
 
 
 requirements = read("requirements.txt", True)

--- a/toripchanger/changer.py
+++ b/toripchanger/changer.py
@@ -1,4 +1,5 @@
 import ipaddress
+import socket
 from time import sleep
 
 from requests import get
@@ -186,7 +187,7 @@ class TorIpChanger:
         Change Tor's IP.
         """
         with Controller.from_port(
-            address=self.tor_address, port=self.tor_port
+            address=socket.gethostbyname(self.tor_address), port=self.tor_port
         ) as controller:
             controller.authenticate(password=self.tor_password)
             controller.signal(Signal.NEWNYM)

--- a/toripchanger/changer.py
+++ b/toripchanger/changer.py
@@ -1,5 +1,4 @@
 import ipaddress
-import socket
 from time import sleep
 
 from requests import get
@@ -187,7 +186,7 @@ class TorIpChanger:
         Change Tor's IP.
         """
         with Controller.from_port(
-            address=socket.gethostbyname(self.tor_address), port=self.tor_port
+            address=self.tor_address, port=self.tor_port
         ) as controller:
             controller.authenticate(password=self.tor_password)
             controller.signal(Signal.NEWNYM)

--- a/toripchanger/server.py
+++ b/toripchanger/server.py
@@ -9,7 +9,7 @@ def create_changeip_response(tor_ip_changer):
     try:
         new_ip = tor_ip_changer.get_new_ip()
     except Exception as exc:
-        error = f"{exc.__class__}: {str(exc)}"
+        error = "{}: {}".format(exc.__class__, str(exc))
         status = 500
 
     response = flask.jsonify({"newIp": new_ip, "error": error})


### PR DESCRIPTION
A few fixes I needed to make so that I can use this very useful package in my setup: I use scrapyd in a docker container (https://hub.docker.com/r/vimagick/scrapyd) which is based on python 3.5. The only Python 3.6+ feature that made the package incompatible is the use of an f-string, which is not a big deal, so this pull request substitutes the f-string with a .format. It works fine on my setup with these minimal changes.